### PR TITLE
second deliverable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,14 @@ module github.com/omar-aguilar/ondemand-go-bootcamp
 
 go 1.17
 
-require github.com/go-chi/chi/v5 v5.0.7
+require (
+	github.com/go-chi/chi/v5 v5.0.7
+	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,21 @@
 package config
 
+import "fmt"
+
 type Config struct {
-	CSVSource string
-	Port      int
+	DBFile      string
+	StoreFolder string
+	Port        int
+}
+
+func (c Config) GetDBPath() string {
+	return fmt.Sprintf("%s/%s", c.StoreFolder, c.DBFile)
 }
 
 var c = Config{
-	CSVSource: "./data/db.csv",
-	Port:      1234,
+	DBFile:      "db.csv",
+	StoreFolder: "./data",
+	Port:        1234,
 }
 
 func GetConfig() Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	baseConfig := GetConfig()
+	expectedDBPath := "./data/db.csv"
+	assert.Equal(t, expectedDBPath, baseConfig.GetDBPath())
+}

--- a/internal/rickandmorty/character_entity.go
+++ b/internal/rickandmorty/character_entity.go
@@ -1,60 +1,20 @@
 package rickandmorty
 
-import (
-	"strconv"
-	"strings"
-)
-
-type Location struct {
-	Name string
-	Url  string
-}
-
-type Origin struct {
-	Name string
-	Url  string
-}
-
-type EpisodeURL = string
-
 type CharacterID = int
 
 type Character struct {
-	ID       CharacterID
-	Name     string
-	Species  string
-	Type     string
-	Gender   string
-	Image    string
-	Url      string
-	Created  string
-	Origin   Origin       `json:"-"`
-	Location Location     `json:"-"`
-	Episode  []EpisodeURL `json:"-"`
+	ID      CharacterID `json:"id"`
+	Name    string      `json:"name"`
+	Species string      `json:"species"`
+	Type    string      `json:"type"`
+	Gender  string      `json:"gender"`
+	Image   string      `json:"image"`
+	Url     string      `json:"url"`
+	Created string      `json:"created"`
 }
 
-type Info struct {
-	Count int
-	Pages int
-	Next  *string
-	Prev  *string
-}
+type CharacterList = []Character
 
 type API struct {
-	Info    Info
-	Results []Character
-}
-
-func (c Character) ToCSVEntry() string {
-	entry := []string{
-		strconv.Itoa(c.ID),
-		c.Name,
-		c.Species,
-		c.Type,
-		c.Gender,
-		c.Image,
-		c.Url,
-		c.Created,
-	}
-	return strings.Join(entry, ",")
+	Results CharacterList
 }

--- a/internal/rickandmorty/character_interactor.go
+++ b/internal/rickandmorty/character_interactor.go
@@ -40,8 +40,7 @@ func (i interactor) LoadAndStore(file io.Reader) error {
 		return err
 	}
 
-	i.storeDS.Write(i.config.DBFile, characterList, FormatCSV)
-	return nil
+	return i.storeDS.Write(i.config.DBFile, characterList, FormatCSV)
 }
 
 func (i interactor) GetById(ID int) (Character, error) {

--- a/internal/rickandmorty/character_interactor.go
+++ b/internal/rickandmorty/character_interactor.go
@@ -1,29 +1,46 @@
 package rickandmorty
 
 import (
+	"fmt"
 	"io"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
 )
 
 type Interactor interface {
-	Load(file io.Reader) error
+	LoadAndStore(file io.Reader) error
 	GetById(ID int) (Character, error)
+	StoreCharactersByPageFromAPI(page int, storageFormat string) (CharacterList, error)
+	GetCharactersStoredByPageFromAPI(page int, storageFormat string) (CharacterList, error)
 }
 
 type interactor struct {
-	ds CharacterRepository
+	config  config.Config
+	ds      CharacterRepository
+	apiDS   APIGetter
+	storeDS CharacterStorer
 }
 
-func NewInteractor(ds CharacterRepository) interactor {
+func getCharactersFilenameFromPage(page int, extension string) string {
+	return fmt.Sprintf("character_%03d.%s", page, extension)
+}
+
+func NewInteractor(config config.Config, ds CharacterRepository, apiDS APIGetter, storeDS CharacterStorer) Interactor {
 	return interactor{
+		config,
 		ds,
+		apiDS,
+		storeDS,
 	}
 }
 
-func (i interactor) Load(file io.Reader) error {
-	err := i.ds.Load(file)
+func (i interactor) LoadAndStore(file io.Reader) error {
+	characterList, err := i.ds.Load(file)
 	if err != nil {
 		return err
 	}
+
+	i.storeDS.Write(i.config.DBFile, characterList, FormatCSV)
 	return nil
 }
 
@@ -35,6 +52,31 @@ func (i interactor) GetById(ID int) (Character, error) {
 	if err != nil {
 		return Character{}, err
 	}
-
 	return character, nil
+}
+
+func (i interactor) StoreCharactersByPageFromAPI(page int, storageFormat string) (CharacterList, error) {
+	if page <= 0 {
+		return CharacterList{}, ErrInvalidPage
+	}
+	characterList, err := i.apiDS.GetCharactersByPage(page)
+	if err != nil {
+		return CharacterList{}, err
+	}
+	filename := getCharactersFilenameFromPage(page, storageFormat)
+	err = i.storeDS.Write(filename, characterList, storageFormat)
+	if err != nil {
+		return CharacterList{}, err
+	}
+	return characterList, err
+}
+
+func (i interactor) GetCharactersStoredByPageFromAPI(page int, storageFormat string) (CharacterList, error) {
+	if page <= 0 {
+		return CharacterList{}, ErrInvalidPage
+	}
+	filename := getCharactersFilenameFromPage(page, storageFormat)
+	characterList := CharacterList{}
+	err := i.storeDS.Read(filename, &characterList, storageFormat)
+	return characterList, err
 }

--- a/internal/rickandmorty/character_interactor_test.go
+++ b/internal/rickandmorty/character_interactor_test.go
@@ -1,0 +1,253 @@
+package rickandmorty
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLoadAndStore(t *testing.T) {
+	type testCase struct {
+		name          string
+		loadError     error
+		writeError    error
+		loadResult    CharacterList
+		expectedError error
+	}
+
+	errLoad := errors.New("error loading file")
+	errWrite := errors.New("error writing file")
+	mockCharacterInput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+
+	testCases := []testCase{
+		{
+			name:       "returns no error",
+			loadResult: CharacterList{mockCharacterInput},
+		},
+		{
+			name:          "returns an error when load fails",
+			loadError:     errLoad,
+			expectedError: errLoad,
+			loadResult:    CharacterList{},
+		},
+		{
+			name:          "returns error when write fails",
+			writeError:    errWrite,
+			expectedError: errWrite,
+			loadResult:    CharacterList{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configMock := config.Config{}
+			characterDSMock := &characterRepositoryMock{}
+			apiGetterDSMock := &apiGetterMock{}
+			characterStorerDSMock := &characterStorerMock{}
+			interactorMock := NewInteractor(configMock, characterDSMock, apiGetterDSMock, characterStorerDSMock)
+			characterDSMock.On("Load", mock.Anything).Return(tc.loadResult, tc.loadError)
+			characterStorerDSMock.On("Write", mock.Anything, mock.Anything, mock.Anything).Return(tc.writeError)
+			err := interactorMock.LoadAndStore(strings.NewReader("test"))
+			assert.Equal(t, tc.expectedError, err)
+			if err == nil {
+				characterStorerDSMock.AssertCalled(t, "Write", configMock.DBFile, tc.loadResult, FormatCSV)
+			}
+		})
+	}
+}
+
+func TestGetById(t *testing.T) {
+	type testCase struct {
+		name           string
+		ID             int
+		expectedError  error
+		expectedOutput Character
+	}
+
+	errGet := errors.New("error getting character")
+	mockCharacterInput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+
+	testCases := []testCase{
+		{
+			name:           "returns valid character",
+			expectedOutput: mockCharacterInput,
+			ID:             1,
+		},
+		{
+			name:           "returns an error for ids lower than or equal to 0",
+			ID:             0,
+			expectedError:  ErrInvalidID,
+			expectedOutput: Character{},
+		},
+		{
+			name:           "returns an error when get by id fails",
+			ID:             1,
+			expectedError:  errGet,
+			expectedOutput: Character{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configMock := config.Config{}
+			characterDSMock := &characterRepositoryMock{}
+			apiGetterDSMock := &apiGetterMock{}
+			characterStorerDSMock := &characterStorerMock{}
+			interactorMock := NewInteractor(configMock, characterDSMock, apiGetterDSMock, characterStorerDSMock)
+			characterDSMock.On("GetById", tc.ID).Return(tc.expectedOutput, tc.expectedError)
+			output, err := interactorMock.GetById(tc.ID)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedOutput, output)
+		})
+	}
+}
+
+func TestStoreCharactersByPageFromAPI(t *testing.T) {
+	type testCase struct {
+		name           string
+		page           int
+		expectedError  error
+		expectedOutput CharacterList
+		getByPageError error
+		writeError     error
+	}
+
+	mockCharacterInput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+
+	errApiCall := errors.New("api call failed")
+	errWrite := errors.New("write error")
+
+	testCases := []testCase{
+		{
+			name:           "returns stored character list",
+			page:           1,
+			expectedOutput: CharacterList{mockCharacterInput},
+		},
+		{
+			name:           "returns an error for page lower than or equal to 0",
+			page:           0,
+			expectedOutput: CharacterList{},
+			expectedError:  ErrInvalidPage,
+		},
+		{
+			name:           "returns an error when api call fail",
+			page:           1,
+			expectedOutput: CharacterList{},
+			getByPageError: errApiCall,
+			expectedError:  errApiCall,
+		},
+		{
+			name:           "returns an error when write fails",
+			page:           1,
+			expectedOutput: CharacterList{},
+			writeError:     errWrite,
+			expectedError:  errWrite,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configMock := config.Config{}
+			characterDSMock := &characterRepositoryMock{}
+			apiGetterDSMock := &apiGetterMock{}
+			characterStorerDSMock := &characterStorerMock{}
+			interactorMock := NewInteractor(configMock, characterDSMock, apiGetterDSMock, characterStorerDSMock)
+			apiGetterDSMock.On("GetCharactersByPage", mock.Anything).Return(tc.expectedOutput, tc.getByPageError)
+			characterStorerDSMock.On("Write", mock.Anything, mock.Anything, mock.Anything).Return(tc.writeError)
+			output, err := interactorMock.StoreCharactersByPageFromAPI(tc.page, FormatJSON)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedOutput, output)
+			if err == nil {
+				characterStorerDSMock.AssertCalled(t, "Write", getCharactersFilenameFromPage(tc.page, FormatJSON), tc.expectedOutput, FormatJSON)
+			}
+		})
+	}
+}
+
+func TestGetCharactersStoredByPageFromAPI(t *testing.T) {
+	type testCase struct {
+		name           string
+		page           int
+		expectedError  error
+		expectedOutput CharacterList
+	}
+
+	mockCharacterInput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+
+	errGet := errors.New("error getting character list")
+	testCases := []testCase{
+		{
+			name:           "returns valid character list",
+			expectedOutput: CharacterList{mockCharacterInput},
+			page:           1,
+		},
+		{
+			name:           "returns an error for ids lower than or equal to 0",
+			page:           0,
+			expectedError:  ErrInvalidPage,
+			expectedOutput: CharacterList{},
+		},
+		{
+			name:           "returns an error when get character list fails",
+			page:           1,
+			expectedError:  errGet,
+			expectedOutput: CharacterList{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configMock := config.Config{}
+			characterDSMock := &characterRepositoryMock{}
+			apiGetterDSMock := &apiGetterMock{}
+			characterStorerDSMock := &characterStorerMock{}
+			interactorMock := NewInteractor(configMock, characterDSMock, apiGetterDSMock, characterStorerDSMock)
+			characterStorerDSMock.On("Read", mock.Anything, mock.Anything, mock.Anything).
+				Return(tc.expectedError).
+				Run(func(args mock.Arguments) {
+					charListPointer := args.Get(1).(*CharacterList)
+					*charListPointer = tc.expectedOutput
+				})
+			output, err := interactorMock.GetCharactersStoredByPageFromAPI(tc.page, FormatJSON)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedOutput, output)
+		})
+	}
+}

--- a/internal/rickandmorty/character_repository.go
+++ b/internal/rickandmorty/character_repository.go
@@ -8,13 +8,31 @@ import (
 var (
 	ErrCharacterNotFound = errors.New("character not found")
 	ErrInvalidID         = errors.New("id should be greater than 0")
+	ErrInvalidPage       = errors.New("page should be greater than 0")
+	ErrInvalidFormat     = errors.New("invalid format")
 )
+
+const FormatCSV = "csv"
+const FormatJSON = "json"
 
 type CharacterGetter interface {
 	GetById(ID int) (Character, error)
 }
 
+type CharacterLoader interface {
+	Load(file io.Reader) (CharacterList, error)
+}
+
+type APIGetter interface {
+	GetCharactersByPage(page int) (CharacterList, error)
+}
+
+type CharacterStorer interface {
+	Write(filename string, data CharacterList, storageFormat string) error
+	Read(filename string, data *CharacterList, storageFormat string) error
+}
+
 type CharacterRepository interface {
 	CharacterGetter
-	Load(file io.Reader) error
+	CharacterLoader
 }

--- a/internal/rickandmorty/datasource/api.go
+++ b/internal/rickandmorty/datasource/api.go
@@ -29,7 +29,7 @@ func (a api) GetCharactersByPage(page int) (rickandmorty.CharacterList, error) {
 	params := url.Values{}
 	params.Add("page", strconv.Itoa(page))
 	requestURL.RawQuery = params.Encode()
-	request, _ := http.NewRequest(http.MethodGet, requestURL.RequestURI(), nil)
+	request, _ := http.NewRequest(http.MethodGet, requestURL.String(), nil)
 	response, err := a.httpClient.Do(request)
 	if err != nil {
 		return rickandmorty.CharacterList{}, err

--- a/internal/rickandmorty/datasource/api.go
+++ b/internal/rickandmorty/datasource/api.go
@@ -1,0 +1,36 @@
+package datasource
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+)
+
+type api struct{}
+
+func NewApiDS() rickandmorty.APIGetter {
+	return api{}
+}
+
+func (a api) GetCharactersByPage(page int) (rickandmorty.CharacterList, error) {
+	baseURL := "https://rickandmortyapi.com/api/character"
+	requestURL, _ := url.Parse(baseURL)
+	params := url.Values{}
+	params.Add("page", strconv.Itoa(page))
+	requestURL.RawQuery = params.Encode()
+
+	response, err := http.Get(requestURL.String())
+	if err != nil {
+		return rickandmorty.CharacterList{}, err
+	}
+
+	api := rickandmorty.API{}
+	err = json.NewDecoder(response.Body).Decode(&api)
+	if err != nil {
+		return rickandmorty.CharacterList{}, err
+	}
+	return api.Results, nil
+}

--- a/internal/rickandmorty/datasource/api_test.go
+++ b/internal/rickandmorty/datasource/api_test.go
@@ -1,0 +1,89 @@
+package datasource
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockHTTPClient struct {
+	mock.Mock
+}
+
+func (h mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	args := h.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+func TestGetCharactersByPage(t *testing.T) {
+	mockCharacterResponse := rickandmorty.API{
+		Results: rickandmorty.CharacterList{
+			{
+				ID:      1,
+				Name:    "Rick Sanchez",
+				Species: "Human",
+				Type:    "",
+				Gender:  "Male",
+				Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+				Url:     "https://rickandmortyapi.com/api/character/1",
+				Created: "2017-11-04T18:48:46.250Z",
+			},
+		},
+	}
+	mockCharacterResponseBytes, _ := json.Marshal(mockCharacterResponse)
+	mockCharacterResponseString := string(mockCharacterResponseBytes)
+
+	type testCase struct {
+		name           string
+		requestOutput  string
+		requestError   error
+		expectedError  error
+		expectedOutput rickandmorty.CharacterList
+	}
+
+	errAPI := errors.New("error from api")
+	errDecode := json.NewDecoder(strings.NewReader("test")).Decode(&testCase{})
+
+	testCases := []testCase{
+		{
+			name:           "returns character list when no errors in request",
+			requestOutput:  mockCharacterResponseString,
+			expectedOutput: mockCharacterResponse.Results,
+		},
+		{
+			name:           "returns error from api when it fails",
+			requestOutput:  "test",
+			requestError:   errAPI,
+			expectedError:  errAPI,
+			expectedOutput: rickandmorty.CharacterList{},
+		},
+		{
+			name:           "returns error when response body is not a valid api response",
+			requestOutput:  "test",
+			expectedError:  errDecode,
+			expectedOutput: rickandmorty.CharacterList{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &mockHTTPClient{}
+			api := NewApiDS(mockClient)
+			responseMock := &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(tc.requestOutput)),
+			}
+			mockClient.On("Do", mock.Anything).Return(responseMock, tc.requestError)
+			output, err := api.GetCharactersByPage(1)
+			assert.Equal(t, tc.expectedOutput, output)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/internal/rickandmorty/datasource/csv.go
+++ b/internal/rickandmorty/datasource/csv.go
@@ -1,27 +1,25 @@
 package datasource
 
 import (
-	"encoding/csv"
 	"errors"
 	"io"
 	"log"
 	"os"
-	"reflect"
-	"strconv"
 
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
 	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
 )
 
 var ErrIncompatibleCSV = errors.New("incompatible csv file")
 
 type csvDS struct {
-	csvSource   string
+	config      config.Config
 	memoryStore MemoryDS
 }
 
-func NewCSVDS(csvSource string, memoryStore MemoryDS) rickandmorty.CharacterRepository {
+func NewCSVDS(config config.Config, memoryStore MemoryDS) rickandmorty.CharacterRepository {
 	ds := csvDS{
-		csvSource,
+		config,
 		memoryStore,
 	}
 	ds.init()
@@ -29,12 +27,12 @@ func NewCSVDS(csvSource string, memoryStore MemoryDS) rickandmorty.CharacterRepo
 }
 
 func (d csvDS) init() {
-	csvFile, err := os.OpenFile(d.csvSource, os.O_RDWR, 0444)
+	csvFile, err := os.OpenFile(d.config.GetDBPath(), os.O_RDWR, 0444)
 	if err != nil {
 		log.Println("empty csv, please make sure to load a csv first")
 		return
 	}
-	err = d.Load(csvFile)
+	_, err = d.Load(csvFile)
 	if err != nil {
 		log.Println("error loading csv file", err.Error())
 		return
@@ -42,70 +40,17 @@ func (d csvDS) init() {
 	log.Println("successfully loaded csv file")
 }
 
-func getCharacterFromRow(row []string) *rickandmorty.Character {
-	id, err := strconv.Atoi(row[0])
-	if err != nil {
-		return nil
-	}
-
-	return &rickandmorty.Character{
-		ID:      id,
-		Name:    row[1],
-		Species: row[2],
-		Type:    row[3],
-		Gender:  row[4],
-		Image:   row[5],
-		Url:     row[6],
-		Created: row[7],
-	}
-}
-
-func (d csvDS) saveDB(header []string, content [][]string) error {
-	expectedHeader := []string{"ID", "Name", "Species", "Type", "Gender", "Image", "Url", "Created"}
-	if !reflect.DeepEqual(expectedHeader, header) {
-		return ErrIncompatibleCSV
-	}
-
-	csvFile, err := os.OpenFile(d.csvSource, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0444)
-	if err != nil {
-		return err
-	}
-	defer csvFile.Close()
-
-	writer := csv.NewWriter(csvFile)
-	writer.Write(header)
-	writer.WriteAll(content)
-	return nil
-}
-
-func (d csvDS) fillMemoryStore(content [][]string) {
-	characterList := []rickandmorty.Character{}
-	for _, row := range content {
-		character := getCharacterFromRow(row)
-		if character == nil {
-			continue
-		}
-		characterList = append(characterList, *character)
-	}
-	d.memoryStore.UpsertDB(characterList)
-}
-
 func (d csvDS) GetById(ID int) (rickandmorty.Character, error) {
 	return d.memoryStore.GetById(ID)
 }
 
-func (d csvDS) Load(file io.Reader) error {
-	csvReader := csv.NewReader(file)
-	data, err := csvReader.ReadAll()
+func (d csvDS) Load(file io.Reader) (rickandmorty.CharacterList, error) {
+	csvCodec := rickandmorty.NewCSVCharacterCodec()
+	characterList := rickandmorty.CharacterList{}
+	err := csvCodec.Decode(file, &characterList)
 	if err != nil {
-		return err
+		return rickandmorty.CharacterList{}, err
 	}
-	header := data[0]
-	content := data[1:]
-	err = d.saveDB(header, content)
-	if err != nil {
-		return err
-	}
-	d.fillMemoryStore(content)
-	return err
+	d.memoryStore.UpsertDB(characterList)
+	return characterList, err
 }

--- a/internal/rickandmorty/datasource/csv_test.go
+++ b/internal/rickandmorty/datasource/csv_test.go
@@ -1,0 +1,122 @@
+package datasource
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoad(t *testing.T) {
+	type testCase struct {
+		name          string
+		input         io.Reader
+		expectedError error
+	}
+
+	mockCharacterDB := rickandmorty.CharacterList{
+		{
+			ID:      1,
+			Name:    "Rick Sanchez",
+			Species: "Human",
+			Type:    "",
+			Gender:  "Male",
+			Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+			Url:     "https://rickandmortyapi.com/api/character/1",
+			Created: "2017-11-04T18:48:46.250Z",
+		},
+	}
+
+	var buff bytes.Buffer
+	rickandmorty.NewCSVCharacterCodec().Encode(bufio.NewWriter(&buff), mockCharacterDB)
+	fileMock := bufio.NewReader(&buff)
+
+	csvWithErrorStr := `1,"`
+	buffWithError := strings.NewReader(csvWithErrorStr)
+	errDecode := rickandmorty.NewCSVCharacterCodec().Decode(buffWithError, &rickandmorty.CharacterList{})
+
+	testCases := []testCase{
+		{
+			name:  "successfully reads an input file",
+			input: fileMock,
+		},
+		{
+			name:          "fails when cannot decode db",
+			input:         strings.NewReader(csvWithErrorStr),
+			expectedError: errDecode,
+		},
+	}
+
+	storeFolder := os.TempDir()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{
+				StoreFolder: storeFolder,
+			}
+			memoryDS := NewMemoryDS()
+			csvDS := NewCSVDS(cfg, memoryDS)
+			_, err := csvDS.Load(tc.input)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}
+
+func TestGetByID(t *testing.T) {
+	type testCase struct {
+		name          string
+		ID            int
+		expectedError error
+	}
+
+	mockCharacterDB := rickandmorty.CharacterList{
+		{
+			ID:      1,
+			Name:    "Rick Sanchez",
+			Species: "Human",
+			Type:    "",
+			Gender:  "Male",
+			Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+			Url:     "https://rickandmortyapi.com/api/character/1",
+			Created: "2017-11-04T18:48:46.250Z",
+		},
+	}
+
+	testCases := []testCase{
+		{
+			name: "successfully reads an input file",
+			ID:   1,
+		},
+		{
+			name:          "returns error when id is not found",
+			ID:            2,
+			expectedError: rickandmorty.ErrCharacterNotFound,
+		},
+	}
+
+	storeFolder := os.TempDir()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{
+				StoreFolder: storeFolder,
+			}
+			memoryDS := NewMemoryDS()
+			csvDS := NewCSVDS(cfg, memoryDS)
+
+			var buff bytes.Buffer
+			rickandmorty.NewCSVCharacterCodec().Encode(bufio.NewWriter(&buff), mockCharacterDB)
+			dbMock := bufio.NewReader(&buff)
+			csvDS.Load(dbMock)
+			_, err := csvDS.GetById(tc.ID)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+
+}

--- a/internal/rickandmorty/datasource/filesystem.go
+++ b/internal/rickandmorty/datasource/filesystem.go
@@ -1,0 +1,63 @@
+package datasource
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+)
+
+type fsImpl struct {
+	config config.Config
+}
+
+func NewFileSystemDS(config config.Config) rickandmorty.CharacterStorer {
+	return fsImpl{
+		config,
+	}
+}
+
+func (f fsImpl) getFilePath(filename string) string {
+	return fmt.Sprintf("%s/%s", f.config.StoreFolder, filename)
+}
+
+func (f fsImpl) Write(filename string, characterList rickandmorty.CharacterList, format string) error {
+	var characterCodec rickandmorty.CharacterCodec
+	switch format {
+	case rickandmorty.FormatCSV:
+		characterCodec = rickandmorty.NewCSVCharacterCodec()
+	case rickandmorty.FormatJSON:
+		characterCodec = rickandmorty.NewJSONCharacterCodec()
+	default:
+		return rickandmorty.ErrInvalidFormat
+	}
+
+	filepath := f.getFilePath(filename)
+	file, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return characterCodec.Encode(file, characterList)
+}
+
+func (f fsImpl) Read(filename string, characterList *rickandmorty.CharacterList, format string) error {
+	filepath := f.getFilePath(filename)
+	file, err := os.OpenFile(filepath, os.O_RDONLY, 0222)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	switch format {
+	case rickandmorty.FormatCSV:
+		csvCodec := rickandmorty.NewCSVCharacterCodec()
+		return csvCodec.Decode(file, characterList)
+	case rickandmorty.FormatJSON:
+		jsonCodec := rickandmorty.NewJSONCharacterCodec()
+		return jsonCodec.Decode(file, characterList)
+	default:
+		return rickandmorty.ErrInvalidFormat
+	}
+}

--- a/internal/rickandmorty/datasource/filesystem_test.go
+++ b/internal/rickandmorty/datasource/filesystem_test.go
@@ -1,0 +1,146 @@
+package datasource
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRead(t *testing.T) {
+	type testCase struct {
+		name           string
+		filename       string
+		format         string
+		expectedError  error
+		expectedOutput rickandmorty.CharacterList
+	}
+
+	mockCharacterList := rickandmorty.CharacterList{
+		{
+			ID:      1,
+			Name:    "Rick Sanchez",
+			Species: "Human",
+			Type:    "",
+			Gender:  "Male",
+			Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+			Url:     "https://rickandmortyapi.com/api/character/1",
+			Created: "2017-11-04T18:48:46.250Z",
+		},
+	}
+
+	storeFolder := os.TempDir()
+
+	mockJSONFile, _ := ioutil.TempFile(storeFolder, "")
+	mockJSONFileName := filepath.Base(mockJSONFile.Name())
+	rickandmorty.NewJSONCharacterCodec().Encode(mockJSONFile, mockCharacterList)
+	mockJSONFile.Close()
+	defer os.Remove(mockJSONFile.Name())
+
+	mockCSVFile, _ := ioutil.TempFile(storeFolder, "")
+	mockCSVFileName := filepath.Base(mockCSVFile.Name())
+	rickandmorty.NewCSVCharacterCodec().Encode(mockCSVFile, mockCharacterList)
+	mockCSVFile.Close()
+	defer os.Remove(mockCSVFile.Name())
+
+	testCases := []testCase{
+		{
+			name:           "succeed to decode in json file",
+			format:         rickandmorty.FormatJSON,
+			filename:       mockJSONFileName,
+			expectedOutput: mockCharacterList,
+		},
+		{
+			name:           "succeed to decode in csv file",
+			format:         rickandmorty.FormatCSV,
+			filename:       mockCSVFileName,
+			expectedOutput: mockCharacterList,
+		},
+		{
+			name:           "fails on invalid format",
+			format:         "some-unsupported-format",
+			expectedError:  rickandmorty.ErrInvalidFormat,
+			expectedOutput: rickandmorty.CharacterList{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{
+				StoreFolder: storeFolder,
+			}
+			fsDS := NewFileSystemDS(cfg)
+			output := rickandmorty.CharacterList{}
+			err := fsDS.Read(tc.filename, &output, tc.format)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedOutput, output)
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	type testCase struct {
+		name          string
+		filename      string
+		format        string
+		expectedError error
+	}
+
+	mockCharacterList := rickandmorty.CharacterList{
+		{
+			ID:      1,
+			Name:    "Rick Sanchez",
+			Species: "Human",
+			Type:    "",
+			Gender:  "Male",
+			Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+			Url:     "https://rickandmortyapi.com/api/character/1",
+			Created: "2017-11-04T18:48:46.250Z",
+		},
+	}
+
+	storeFolder := os.TempDir()
+
+	mockJSONFile, _ := ioutil.TempFile(storeFolder, "")
+	mockJSONFileName := filepath.Base(mockJSONFile.Name())
+	mockJSONFile.Close()
+	defer os.Remove(mockJSONFile.Name())
+
+	mockCSVFile, _ := ioutil.TempFile(storeFolder, "")
+	mockCSVFileName := filepath.Base(mockCSVFile.Name())
+	mockCSVFile.Close()
+	defer os.Remove(mockCSVFile.Name())
+
+	testCases := []testCase{
+		{
+			name:     "succeed to decode in json file",
+			format:   rickandmorty.FormatJSON,
+			filename: mockJSONFileName,
+		},
+		{
+			name:     "succeed to decode in csv file",
+			format:   rickandmorty.FormatCSV,
+			filename: mockCSVFileName,
+		},
+		{
+			name:          "fails on invalid format",
+			format:        "some-unsupported-format",
+			expectedError: rickandmorty.ErrInvalidFormat,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Config{
+				StoreFolder: storeFolder,
+			}
+			fsDS := NewFileSystemDS(cfg)
+			err := fsDS.Write(tc.filename, mockCharacterList, tc.format)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/internal/rickandmorty/datasource/memory.go
+++ b/internal/rickandmorty/datasource/memory.go
@@ -6,7 +6,7 @@ import (
 
 type MemoryDS interface {
 	rickandmorty.CharacterGetter
-	UpsertDB(entries []rickandmorty.Character)
+	UpsertDB(entries rickandmorty.CharacterList)
 }
 
 type DB = map[rickandmorty.CharacterID]rickandmorty.Character

--- a/internal/rickandmorty/mocks_test.go
+++ b/internal/rickandmorty/mocks_test.go
@@ -1,0 +1,44 @@
+package rickandmorty
+
+import (
+	"io"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type characterRepositoryMock struct {
+	mock.Mock
+}
+
+func (c *characterRepositoryMock) GetById(ID int) (Character, error) {
+	args := c.Called(ID)
+	return args.Get(0).(Character), args.Error(1)
+}
+
+func (c *characterRepositoryMock) Load(file io.Reader) (CharacterList, error) {
+	args := c.Called(file)
+	return args.Get(0).(CharacterList), args.Error(1)
+}
+
+type apiGetterMock struct {
+	mock.Mock
+}
+
+func (a *apiGetterMock) GetCharactersByPage(page int) (CharacterList, error) {
+	args := a.Called(page)
+	return args.Get(0).(CharacterList), args.Error(1)
+}
+
+type characterStorerMock struct {
+	mock.Mock
+}
+
+func (s *characterStorerMock) Write(filename string, data CharacterList, storageFormat string) error {
+	args := s.Called(filename, data, storageFormat)
+	return args.Error(0)
+}
+
+func (s *characterStorerMock) Read(filename string, data *CharacterList, storageFormat string) error {
+	args := s.Called(filename, data, storageFormat)
+	return args.Error(0)
+}

--- a/internal/rickandmorty/transport/cli.go
+++ b/internal/rickandmorty/transport/cli.go
@@ -1,40 +1,46 @@
 package transport
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
 
-func cliLoadCSV(file *os.File) {
+var ErrEmptyFile = errors.New("empty file")
+var ErrFileStats = errors.New("stats error in file")
+
+func cliLoadCSV(file *os.File) error {
 	stats, err := file.Stat()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
+		return ErrFileStats
 	}
 	isEmptyFile := stats.Size() == 0
 	if isEmptyFile {
-		return
+		return ErrEmptyFile
 	}
-	interactor.LoadAndStore(file)
+	return interactor.LoadAndStore(file)
 }
 
-func CLILoadCSVFromFileName(filename string) {
+func CLILoadCSVFromFileName(filename string) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
-		return
+		return err
 	}
-	cliLoadCSV(file)
+	return cliLoadCSV(file)
 }
 
-func CLILoadCSVFromStdin() {
-	cliLoadCSV(os.Stdin)
+func CLILoadCSVFromStdin(stdin *os.File) error {
+	return cliLoadCSV(stdin)
 }
 
-func CLIGetCharacterById(ID int, format string) {
+func CLIGetCharacterById(ID int, format string) error {
 	character, err := interactor.GetById(ID)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
-		return
+		return err
 	}
 	writeFormattedResponse(os.Stdout, character, format)
+	return nil
 }

--- a/internal/rickandmorty/transport/cli.go
+++ b/internal/rickandmorty/transport/cli.go
@@ -14,7 +14,7 @@ func cliLoadCSV(file *os.File) {
 	if isEmptyFile {
 		return
 	}
-	interactor.Load(file)
+	interactor.LoadAndStore(file)
 }
 
 func CLILoadCSVFromFileName(filename string) {
@@ -36,5 +36,5 @@ func CLIGetCharacterById(ID int, format string) {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return
 	}
-	writeFormattedCharacter(os.Stdout, character, format)
+	writeFormattedResponse(os.Stdout, character, format)
 }

--- a/internal/rickandmorty/transport/cli_test.go
+++ b/internal/rickandmorty/transport/cli_test.go
@@ -1,0 +1,158 @@
+package transport
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCLILoadCSVFromFileName(t *testing.T) {
+	type testCase struct {
+		name          string
+		loadError     error
+		expectedError error
+		filename      string
+	}
+
+	tempFile, _ := ioutil.TempFile(os.TempDir(), "")
+	tempFile.Write([]byte("test"))
+	tempFilename := tempFile.Name()
+	tempFile.Close()
+
+	tempEmptyFile, _ := ioutil.TempFile(os.TempDir(), "")
+	tempEmptyFilename := tempEmptyFile.Name()
+	tempEmptyFile.Close()
+
+	unexistentFilename := "unexistent-test-file.abc"
+	_, errUnexistentFile := os.Open(unexistentFilename)
+
+	errLoad := errors.New("error in load and store")
+
+	testCases := []testCase{
+		{
+			name:     "loads file successfully",
+			filename: tempFilename,
+		},
+		{
+			name:          "fails when file is empty",
+			filename:      tempEmptyFilename,
+			expectedError: ErrEmptyFile,
+		},
+		{
+			name:          "fails to load when the file is invalid",
+			filename:      unexistentFilename,
+			expectedError: errUnexistentFile,
+		},
+		{
+			name:          "fails when load and store sends an error",
+			filename:      tempFilename,
+			loadError:     errLoad,
+			expectedError: errLoad,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("LoadAndStore", mock.Anything).Return(tc.loadError)
+			err := CLILoadCSVFromFileName(tc.filename)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+
+	os.Remove(tempFilename)
+	os.Remove(tempEmptyFilename)
+}
+
+func TestCLILoadCSVFromStdin(t *testing.T) {
+	type testCase struct {
+		name          string
+		loadError     error
+		expectedError error
+		stdinInput    *os.File
+	}
+
+	tempFile, _ := ioutil.TempFile(os.TempDir(), "")
+	tempFile.Write([]byte("test"))
+	tempFilename := tempFile.Name()
+	defer tempFile.Close()
+
+	tempEmptyFile, _ := ioutil.TempFile(os.TempDir(), "")
+	tempEmptyFilename := tempEmptyFile.Name()
+	defer tempEmptyFile.Close()
+	errLoad := errors.New("error in load and store")
+
+	testCases := []testCase{
+		{
+			name:       "loads file successfully",
+			stdinInput: tempFile,
+		},
+		{
+			name:          "fails when file is empty",
+			stdinInput:    tempEmptyFile,
+			expectedError: ErrEmptyFile,
+		},
+		{
+			name:          "fails when file is nil",
+			expectedError: ErrFileStats,
+		},
+		{
+			name:          "fails when load and store sends an error",
+			stdinInput:    tempFile,
+			loadError:     errLoad,
+			expectedError: errLoad,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("LoadAndStore", mock.Anything).Return(tc.loadError)
+			err := CLILoadCSVFromStdin(tc.stdinInput)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+
+	os.Remove(tempFilename)
+	os.Remove(tempEmptyFilename)
+}
+
+func TestCLIGetCharacterById(t *testing.T) {
+	type testCase struct {
+		name          string
+		expectedError error
+		ID            int
+	}
+
+	errGet := errors.New("error getting character")
+
+	testCases := []testCase{
+		{
+			name: "gets character successfully",
+			ID:   1,
+		},
+		{
+			name:          "fails when get by if fails",
+			ID:            0,
+			expectedError: errGet,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("GetById", mock.Anything).Return(rickandmorty.Character{}, tc.expectedError)
+			err := CLIGetCharacterById(tc.ID, rickandmorty.FormatJSON)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+
+}

--- a/internal/rickandmorty/transport/http_test.go
+++ b/internal/rickandmorty/transport/http_test.go
@@ -1,0 +1,206 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestHTTPLoadCharactersCSV(t *testing.T) {
+	type testCase struct {
+		name        string
+		fileContent io.Reader
+		loadError   error
+		statusCode  int
+	}
+
+	errLoad := errors.New("load error")
+	testCases := []testCase{
+		{
+			name:        "fails with bad request when there is an error in form file",
+			fileContent: nil,
+			statusCode:  400,
+		},
+		{
+			name:        "fails with bad request when there is an error in load an store",
+			fileContent: strings.NewReader("test"),
+			loadError:   errLoad,
+			statusCode:  400,
+		},
+		{
+			name:        "sends ok when loads file correctly",
+			fileContent: strings.NewReader("test"),
+			statusCode:  200,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("LoadAndStore", mock.Anything).Return(tc.loadError)
+			body := new(bytes.Buffer)
+			writer := multipart.NewWriter(body)
+			if tc.fileContent != nil {
+				fmt.Println("tc.name", tc.name)
+				part, _ := writer.CreateFormFile(formFileCSV, "test.csv")
+				io.Copy(part, tc.fileContent)
+				writer.Close()
+			}
+			r := httptest.NewRequest(http.MethodPost, "/rickandmorty/load-csv", body)
+			r.Header.Set("Content-Type", writer.FormDataContentType())
+			r.Header.Set("Content-Length", fmt.Sprintf("%d", body.Len()))
+			w := httptest.NewRecorder()
+			HTTPLoadCharactersCSV(w, r)
+			assert.Equal(t, tc.statusCode, w.Code)
+		})
+	}
+}
+func TestHTTPGetCharacterById(t *testing.T) {
+	type testCase struct {
+		name       string
+		statusCode int
+		getError   error
+		ID         int
+	}
+
+	errGet := errors.New("error getting item")
+	testCases := []testCase{
+		{
+			name:       "sends bad request when ID param is not found in the url",
+			statusCode: 400,
+		},
+		{
+			name:       "sends not found when get by id fails",
+			statusCode: 404,
+			ID:         1,
+			getError:   errGet,
+		},
+		{
+			name:       "sends ok when everything works as expected",
+			statusCode: 200,
+			ID:         1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("GetById", mock.Anything).Return(rickandmorty.Character{}, tc.getError)
+			url := fmt.Sprintf("/rickandmorty/character/%d", tc.ID)
+			r := httptest.NewRequest(http.MethodGet, url, nil)
+			routerCtx := chi.NewRouteContext()
+			if tc.ID != 0 {
+				routerCtx.URLParams.Add(paramID, strconv.Itoa(tc.ID))
+			}
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routerCtx))
+			w := httptest.NewRecorder()
+			HTTPGetCharacterById(w, r)
+			assert.Equal(t, tc.statusCode, w.Code)
+		})
+	}
+}
+func TestHTTPGetCharactersFromAPI(t *testing.T) {
+	type testCase struct {
+		name       string
+		statusCode int
+		storeError error
+		ID         int
+	}
+
+	errStore := errors.New("error storing")
+	testCases := []testCase{
+		{
+			name:       "sends bad request when ID param is not found in the url",
+			statusCode: 400,
+		},
+		{
+			name:       "sends failed dependency when store fails",
+			statusCode: 424,
+			ID:         1,
+			storeError: errStore,
+		},
+		{
+			name:       "sends ok when everything works as expected",
+			statusCode: 200,
+			ID:         1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("StoreCharactersByPageFromAPI", mock.Anything, mock.Anything).Return(rickandmorty.CharacterList{}, tc.storeError)
+			url := fmt.Sprintf("/rickandmorty/character/%d", tc.ID)
+			r := httptest.NewRequest(http.MethodGet, url, nil)
+			routerCtx := chi.NewRouteContext()
+			if tc.ID != 0 {
+				routerCtx.URLParams.Add(paramPage, strconv.Itoa(tc.ID))
+			}
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routerCtx))
+			w := httptest.NewRecorder()
+			HTTPGetCharactersFromAPI(w, r)
+			assert.Equal(t, tc.statusCode, w.Code)
+		})
+	}
+}
+func TestHTTPGetCharactersStoredFromAPI(t *testing.T) {
+	type testCase struct {
+		name              string
+		statusCode        int
+		getFromStoreError error
+		ID                int
+	}
+
+	errStore := errors.New("error storing")
+	testCases := []testCase{
+		{
+			name:       "sends bad request when ID param is not found in the url",
+			statusCode: 400,
+		},
+		{
+			name:              "sends failed dependency when get from store fails",
+			statusCode:        424,
+			ID:                1,
+			getFromStoreError: errStore,
+		},
+		{
+			name:       "sends ok when everything works as expected",
+			statusCode: 200,
+			ID:         1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iMock := interactorMock{}
+			interactor = &iMock
+			iMock.On("GetCharactersStoredByPageFromAPI", mock.Anything, mock.Anything).Return(rickandmorty.CharacterList{}, tc.getFromStoreError)
+			url := fmt.Sprintf("/rickandmorty/character/%d?%s=%s", tc.ID, queryOutputFormat, rickandmorty.FormatCSV)
+			r := httptest.NewRequest(http.MethodGet, url, nil)
+			routerCtx := chi.NewRouteContext()
+			if tc.ID != 0 {
+				routerCtx.URLParams.Add(paramPage, strconv.Itoa(tc.ID))
+			}
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routerCtx))
+			w := httptest.NewRecorder()
+			HTTPGetCharactersStoredFromAPI(w, r)
+			assert.Equal(t, tc.statusCode, w.Code)
+		})
+	}
+}

--- a/internal/rickandmorty/transport/init.go
+++ b/internal/rickandmorty/transport/init.go
@@ -10,8 +10,9 @@ var interactor rickandmorty.Interactor
 
 func init() {
 	config := config.GetConfig()
-	csvSource := config.CSVSource
 	memoryStore := datasource.NewMemoryDS()
-	datastore := datasource.NewCSVDS(csvSource, memoryStore)
-	interactor = rickandmorty.NewInteractor(datastore)
+	characterDS := datasource.NewCSVDS(config, memoryStore)
+	apiDS := datasource.NewApiDS()
+	fsDS := datasource.NewFileSystemDS(config)
+	interactor = rickandmorty.NewInteractor(config, characterDS, apiDS, fsDS)
 }

--- a/internal/rickandmorty/transport/init.go
+++ b/internal/rickandmorty/transport/init.go
@@ -1,6 +1,8 @@
 package transport
 
 import (
+	"net/http"
+
 	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/config"
 	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
 	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty/datasource"
@@ -12,7 +14,7 @@ func init() {
 	config := config.GetConfig()
 	memoryStore := datasource.NewMemoryDS()
 	characterDS := datasource.NewCSVDS(config, memoryStore)
-	apiDS := datasource.NewApiDS()
+	apiDS := datasource.NewApiDS(http.DefaultClient)
 	fsDS := datasource.NewFileSystemDS(config)
 	interactor = rickandmorty.NewInteractor(config, characterDS, apiDS, fsDS)
 }

--- a/internal/rickandmorty/transport/mocks_test.go
+++ b/internal/rickandmorty/transport/mocks_test.go
@@ -1,0 +1,32 @@
+package transport
+
+import (
+	"io"
+
+	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
+	"github.com/stretchr/testify/mock"
+)
+
+type interactorMock struct {
+	mock.Mock
+}
+
+func (i *interactorMock) LoadAndStore(file io.Reader) error {
+	args := i.Called(file)
+	return args.Error(0)
+}
+
+func (i *interactorMock) GetById(ID int) (rickandmorty.Character, error) {
+	args := i.Called(ID)
+	return args.Get(0).(rickandmorty.Character), args.Error(1)
+}
+
+func (i *interactorMock) StoreCharactersByPageFromAPI(page int, storageFormat string) (rickandmorty.CharacterList, error) {
+	args := i.Called(page, storageFormat)
+	return args.Get(0).(rickandmorty.CharacterList), args.Error(1)
+}
+
+func (i *interactorMock) GetCharactersStoredByPageFromAPI(page int, storageFormat string) (rickandmorty.CharacterList, error) {
+	args := i.Called(page, storageFormat)
+	return args.Get(0).(rickandmorty.CharacterList), args.Error(1)
+}

--- a/internal/rickandmorty/transport/util.go
+++ b/internal/rickandmorty/transport/util.go
@@ -1,18 +1,18 @@
 package transport
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/omar-aguilar/ondemand-go-bootcamp/internal/rickandmorty"
 )
 
-func writeFormattedCharacter(channel io.Writer, character rickandmorty.Character, format string) {
+func writeFormattedResponse(channel io.Writer, characterData interface{}, format string) {
 	switch format {
-	case "csv":
-		fmt.Fprintln(channel, character.ToCSVEntry())
+	case rickandmorty.FormatCSV:
+		csvCodec := rickandmorty.NewCSVCharacterCodec()
+		csvCodec.Encode(channel, characterData)
 	default:
-		json.NewEncoder(channel).Encode(character)
+		csvCodec := rickandmorty.NewJSONCharacterCodec()
+		csvCodec.Encode(channel, characterData)
 	}
 }

--- a/internal/rickandmorty/util.go
+++ b/internal/rickandmorty/util.go
@@ -1,0 +1,134 @@
+package rickandmorty
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+)
+
+var (
+	ErrInvalidCodecFormat = errors.New("invalid codec format")
+	ErrEmptyCSV           = errors.New("empty csv")
+)
+
+type CharacterCodec interface {
+	Encode(writer io.Writer, data interface{}) error
+	Decode(reader io.Reader, data interface{}) error
+}
+
+type jsonCodec struct{}
+
+func NewJSONCharacterCodec() CharacterCodec {
+	return jsonCodec{}
+}
+func (j jsonCodec) Encode(writer io.Writer, data interface{}) error {
+	switch data.(type) {
+	case Character, CharacterList:
+		return json.NewEncoder(writer).Encode(data)
+	default:
+		return ErrInvalidCodecFormat
+	}
+}
+func (j jsonCodec) Decode(reader io.Reader, data interface{}) error {
+	switch data.(type) {
+	case *Character, *CharacterList:
+		return json.NewDecoder(reader).Decode(data)
+	default:
+		return ErrInvalidCodecFormat
+	}
+}
+
+type csvCodec struct {
+	header []string
+}
+
+func NewCSVCharacterCodec() CharacterCodec {
+	return csvCodec{
+		header: []string{"ID", "Name", "Species", "Type", "Gender", "Image", "Url", "Created"},
+	}
+}
+func (j csvCodec) getCSVRowFromCharacter(character Character) []string {
+	return []string{
+		strconv.Itoa(character.ID),
+		character.Name,
+		character.Species,
+		character.Type,
+		character.Gender,
+		character.Image,
+		character.Url,
+		character.Created,
+	}
+}
+func (j csvCodec) getCharacterFromCSVRow(characterRow []string) Character {
+	id, _ := strconv.Atoi(characterRow[0])
+	return Character{
+		ID:      id,
+		Name:    characterRow[1],
+		Species: characterRow[2],
+		Type:    characterRow[3],
+		Gender:  characterRow[4],
+		Image:   characterRow[5],
+		Url:     characterRow[6],
+		Created: characterRow[7],
+	}
+}
+func (j csvCodec) Encode(writer io.Writer, data interface{}) error {
+	csvHeader := j.header
+	csvData := [][]string{}
+	csvData = append(csvData, csvHeader)
+	switch dataOfType := data.(type) {
+	case CharacterList:
+		for _, character := range dataOfType {
+			row := j.getCSVRowFromCharacter(character)
+			csvData = append(csvData, row)
+		}
+	case Character:
+		row := j.getCSVRowFromCharacter(dataOfType)
+		csvData = append(csvData, row)
+	default:
+		return ErrInvalidCodecFormat
+	}
+	csvWriter := csv.NewWriter(writer)
+	return csvWriter.WriteAll(csvData)
+}
+
+func (j csvCodec) Decode(reader io.Reader, data interface{}) error {
+	csvHeader := j.header
+	csvReader := csv.NewReader(reader)
+	csvData, err := csvReader.ReadAll()
+	if err != nil {
+		return err
+	}
+
+	if len(csvData) == 0 {
+		return ErrEmptyCSV
+	}
+	hasHeader := len(csvData) > 1 && reflect.DeepEqual(csvHeader, csvData[0])
+
+	switch dataOfType := data.(type) {
+	case *Character:
+		characterRow := csvData[0]
+		if hasHeader {
+			characterRow = csvData[1]
+		}
+		character := j.getCharacterFromCSVRow(characterRow)
+		*dataOfType = character
+	case *CharacterList:
+		characterRowList := csvData
+		if hasHeader {
+			characterRowList = csvData[1:]
+		}
+		characterList := CharacterList{}
+		for _, characterRow := range characterRowList {
+			character := j.getCharacterFromCSVRow(characterRow)
+			characterList = append(characterList, character)
+		}
+		*dataOfType = characterList
+	default:
+		return ErrInvalidCodecFormat
+	}
+	return nil
+}

--- a/internal/rickandmorty/util.go
+++ b/internal/rickandmorty/util.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrInvalidCodecFormat = errors.New("invalid codec format")
 	ErrEmptyCSV           = errors.New("empty csv")
+	ErrDecodeInput        = errors.New("cannot decode input")
 )
 
 type CharacterCodec interface {
@@ -35,7 +36,11 @@ func (j jsonCodec) Encode(writer io.Writer, data interface{}) error {
 func (j jsonCodec) Decode(reader io.Reader, data interface{}) error {
 	switch data.(type) {
 	case *Character, *CharacterList:
-		return json.NewDecoder(reader).Decode(data)
+		err := json.NewDecoder(reader).Decode(data)
+		if err != nil {
+			return ErrDecodeInput
+		}
+		return nil
 	default:
 		return ErrInvalidCodecFormat
 	}
@@ -100,7 +105,7 @@ func (j csvCodec) Decode(reader io.Reader, data interface{}) error {
 	csvReader := csv.NewReader(reader)
 	csvData, err := csvReader.ReadAll()
 	if err != nil {
-		return err
+		return ErrDecodeInput
 	}
 
 	if len(csvData) == 0 {

--- a/internal/rickandmorty/util_test.go
+++ b/internal/rickandmorty/util_test.go
@@ -1,0 +1,272 @@
+package rickandmorty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getJSONString(data interface{}) string {
+	var buffer bytes.Buffer
+	json.NewEncoder(&buffer).Encode(data)
+	return buffer.String()
+}
+
+func TestJSONEncode(t *testing.T) {
+	type testCase struct {
+		name           string
+		data           interface{}
+		expectedOutput string
+		expectedErr    error
+	}
+
+	mockCharacterInput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+	mockCharacterListInput := CharacterList{mockCharacterInput}
+	mockCharacterOutput := getJSONString(mockCharacterInput)
+	mockCharacterListOutput := getJSONString(mockCharacterListInput)
+
+	testCases := []testCase{
+		{
+			name:           "encodes a character list",
+			data:           mockCharacterListInput,
+			expectedOutput: mockCharacterListOutput,
+			expectedErr:    nil,
+		},
+		{
+			name:           "encodes a single character",
+			data:           mockCharacterInput,
+			expectedOutput: mockCharacterOutput,
+			expectedErr:    nil,
+		},
+		{
+			name:           "fails with invalid data type",
+			data:           []string{"test"},
+			expectedErr:    ErrInvalidCodecFormat,
+			expectedOutput: "",
+		},
+	}
+
+	jsonCodec := NewJSONCharacterCodec()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			err := jsonCodec.Encode(&buffer, tc.data)
+			assert.ErrorIs(t, err, tc.expectedErr)
+			assert.Equal(t, tc.expectedOutput, buffer.String())
+		})
+	}
+}
+
+func TestJSONDecode(t *testing.T) {
+	type testCase struct {
+		name           string
+		reader         io.Reader
+		dataReceiver   interface{}
+		expectedOutput interface{}
+		expectedErr    error
+	}
+
+	mockCharacterInput := `{
+		"id": 1,
+		"name": "Rick Sanchez",
+		"species": "Human",
+		"type": "",
+		"gender": "Male",
+		"image": "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		"url": "https://rickandmortyapi.com/api/character/1",
+		"created": "2017-11-04T18:48:46.250Z"
+	}`
+	mockCharacterListInput := fmt.Sprintf("[%s]", mockCharacterInput)
+
+	mockCharacterOutput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+	mockCharacterListOutput := CharacterList{mockCharacterOutput}
+
+	testCases := []testCase{
+		{
+			name:           "decodes a character list",
+			dataReceiver:   &CharacterList{},
+			reader:         strings.NewReader(mockCharacterListInput),
+			expectedErr:    nil,
+			expectedOutput: &mockCharacterListOutput,
+		},
+		{
+			name:           "decodes a single character",
+			dataReceiver:   &Character{},
+			reader:         strings.NewReader(mockCharacterInput),
+			expectedErr:    nil,
+			expectedOutput: &mockCharacterOutput,
+		},
+		{
+			name:           "fails to decode a valid type",
+			reader:         strings.NewReader("test"),
+			dataReceiver:   &Character{},
+			expectedErr:    ErrDecodeInput,
+			expectedOutput: &Character{},
+		},
+		{
+			name:           "fails with invalid data receiver",
+			reader:         strings.NewReader("test"),
+			dataReceiver:   &[]string{"test"},
+			expectedErr:    ErrInvalidCodecFormat,
+			expectedOutput: &[]string{"test"},
+		},
+	}
+
+	jsonCodec := NewJSONCharacterCodec()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := jsonCodec.Decode(tc.reader, tc.dataReceiver)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedOutput, tc.dataReceiver)
+		})
+	}
+}
+
+func TestCSVEncode(t *testing.T) {
+	type testCase struct {
+		name           string
+		data           interface{}
+		expectedOutput string
+		expectedErr    error
+	}
+
+	mockCharacterInput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+	mockCharacterListInput := CharacterList{mockCharacterInput}
+	mockCharacterOutput := "ID,Name,Species,Type,Gender,Image,Url,Created\n1,Rick Sanchez,Human,,Male,https://rickandmortyapi.com/api/character/avatar/1.jpeg,https://rickandmortyapi.com/api/character/1,2017-11-04T18:48:46.250Z\n"
+	mockCharacterListOutput := mockCharacterOutput
+
+	testCases := []testCase{
+		{
+			name:           "encodes a character list",
+			data:           mockCharacterListInput,
+			expectedErr:    nil,
+			expectedOutput: mockCharacterListOutput,
+		},
+		{
+			name:           "encodes a single character",
+			data:           mockCharacterInput,
+			expectedErr:    nil,
+			expectedOutput: mockCharacterOutput,
+		},
+		{
+			name:           "fails with invalid data type",
+			data:           []string{"test"},
+			expectedErr:    ErrInvalidCodecFormat,
+			expectedOutput: "",
+		},
+	}
+
+	csvCodec := NewCSVCharacterCodec()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			err := csvCodec.Encode(&buffer, tc.data)
+			assert.ErrorIs(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedOutput, buffer.String())
+		})
+	}
+}
+
+func TestCSVDecode(t *testing.T) {
+	type testCase struct {
+		name           string
+		reader         io.Reader
+		dataReceiver   interface{}
+		expectedOutput interface{}
+		expectedErr    error
+	}
+
+	mockCharacterInput := "ID,Name,Species,Type,Gender,Image,Url,Created\n1,Rick Sanchez,Human,,Male,https://rickandmortyapi.com/api/character/avatar/1.jpeg,https://rickandmortyapi.com/api/character/1,2017-11-04T18:48:46.250Z\n"
+	mockCharacterListInput := mockCharacterInput
+
+	mockCharacterOutput := Character{
+		ID:      1,
+		Name:    "Rick Sanchez",
+		Species: "Human",
+		Type:    "",
+		Gender:  "Male",
+		Image:   "https://rickandmortyapi.com/api/character/avatar/1.jpeg",
+		Url:     "https://rickandmortyapi.com/api/character/1",
+		Created: "2017-11-04T18:48:46.250Z",
+	}
+	mockCharacterListOutput := CharacterList{mockCharacterOutput}
+
+	testCases := []testCase{
+		{
+			name:           "decodes a character list",
+			dataReceiver:   &CharacterList{},
+			reader:         strings.NewReader(mockCharacterListInput),
+			expectedErr:    nil,
+			expectedOutput: &mockCharacterListOutput,
+		},
+		{
+			name:           "decodes a single character",
+			dataReceiver:   &Character{},
+			reader:         strings.NewReader(mockCharacterInput),
+			expectedErr:    nil,
+			expectedOutput: &mockCharacterOutput,
+		},
+		{
+			name:           "fails with empty csv",
+			reader:         strings.NewReader(""),
+			dataReceiver:   &Character{},
+			expectedErr:    ErrEmptyCSV,
+			expectedOutput: &Character{},
+		},
+		{
+			name:           "fails to decode a valid type",
+			reader:         strings.NewReader(`1,"`),
+			dataReceiver:   &Character{},
+			expectedErr:    ErrDecodeInput,
+			expectedOutput: &Character{},
+		},
+		{
+			name:           "fails with invalid data receiver",
+			reader:         strings.NewReader("test"),
+			dataReceiver:   &[]string{"test"},
+			expectedErr:    ErrInvalidCodecFormat,
+			expectedOutput: &[]string{"test"},
+		},
+	}
+
+	csvCodec := NewCSVCharacterCodec()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := csvCodec.Decode(tc.reader, tc.dataReceiver)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedOutput, tc.dataReceiver)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,8 +15,12 @@ func startRouter() {
 	config := config.GetConfig()
 	router := chi.NewRouter()
 	router.Route("/rickandmorty", func(r chi.Router) {
-		r.Post("/load", ram.HTTPLoadCSV)
-		r.Get("/{id}", ram.HTTPGetCharacterById)
+		r.Route("/external-api/{page}", func(api chi.Router) {
+			api.Get("/load-stored", ram.HTTPGetCharactersStoredFromAPI)
+			api.Get("/store", ram.HTTPGetCharactersFromAPI)
+		})
+		r.Post("/load-csv", ram.HTTPLoadCharactersCSV)
+		r.Get("/character/{id}", ram.HTTPGetCharacterById)
 	})
 	addr := fmt.Sprintf("127.0.0.1:%d", config.Port)
 	http.ListenAndServe(addr, router)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func startCLI() {
 
 	switch {
 	case hasStdinInput:
-		ram.CLILoadCSVFromStdin()
+		ram.CLILoadCSVFromStdin(os.Stdin)
 	case hasCsvFilename:
 		ram.CLILoadCSVFromFileName(*csvFilename)
 	case isCharacterRequest:


### PR DESCRIPTION
## Load from external API
The url to get something from the external api has the format `http://localhost:1234/rickandmorty/external-api/{page}/store`
There are 2 query parameters:
1. `inputFormat` which refers to the format that is going to be used to store the results from the external api, it can be `csv` or `json`.
1. `outputFormat` refers to the format that is going to be used to display as response to the request, either `csv` or `json`, defaults to `json`

To save the page 1 from the external api will be like:
`curl -i http://localhost:1234/rickandmorty/external-api/1/store?inputFormat=csv`
`curl -i http://localhost:1234/rickandmorty/external-api/1/store?inputFormat=json`
Both will store a new within the `data` folder, the format of the file is `character_{page_0_padded}.{csv|json}`

To retrieve an stored page is like:
`curl -i http://localhost:1234/rickandmorty/external-api/1/load-stored?inputFormat=json`
`curl -i http://localhost:1234/rickandmorty/external-api/1/load-stored?inputFormat=csv`

the `inputFormat` query parameter will indicate which of the stored files to look for


## Get single character
The url call looks like: `http://localhost:1234/rickandmorty/character/{character_id}`
There is one query parameter `outputFormat` which will indicate the format of the response, either `csv` or `json`, defaults to `json`

`curl -i http://localhost:1234/rickandmorty/character/1?outputFormat=csv`
`curl -i http://localhost:1234/rickandmorty/character/1?outputFormat=json`



